### PR TITLE
fix: social links to twitter and github repo

### DIFF
--- a/docs/v1/theme.config.ts
+++ b/docs/v1/theme.config.ts
@@ -1,4 +1,4 @@
-import { defineTheme } from '@nuxt-themes/kit'
+import { defineTheme } from '@nuxt-themes/config'
 
 //
 // title: '@vueuse/schema-org',


### PR DESCRIPTION
### Description 📖 

This pull request fixes the _GitHub_ and _Twitter_ social links in the header and footer of the new documentation website.

### Background 📜 

Previously, [the docs site](https://vue-schema-org.netlify.app/) was using the defaults for Docus.

Since the import in `theme.config.ts` was incorrect, it seems like Nuxt silently ignored the error and kept the defaults.

### The Fix 🔨 

Importing from '@nuxt-themes/config' instead of '@nuxt-themes/kit'.