### PR TITLE
fix: add a missing s in layouts

### DIFF
--- a/docs/v1/content/1.guide/1.getting-started/2.nuxt.md
+++ b/docs/v1/content/1.guide/1.getting-started/2.nuxt.md
@@ -72,7 +72,7 @@ See the [User Config page](/guide/guides/user-config) for all options you can pa
 
 To quickly add the recommended Schema.org to all pages, you can make use [Runtime Inferences](/guide/getting-started/how-it-works#runtime-inferences).
 
-This should be done in either your `app.vue` or `layout/default.vue` file.
+This should be done in either your `app.vue` or `layouts/default.vue` file.
 
 ::code-group
 


### PR DESCRIPTION
As written [in nuxt docs](http://v3.nuxtjs.org/guide/directory-structure/layouts), `layouts` have a s.