### PR TITLE
chore: loosen nuxt kit version

### DIFF
--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -40,7 +40,7 @@
     "play:build": "nuxi build ../../test/fixtures/nuxt"
   },
   "dependencies": {
-    "@nuxt/kit": "3.4.2",
+    "@nuxt/kit": "^3.4.2",
     "@unhead/schema-org-vue": "^0.5.0",
     "pathe": "^1.1.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,7 +50,7 @@ importers:
   packages/nuxt:
     dependencies:
       '@nuxt/kit':
-        specifier: 3.4.2
+        specifier: ^3.4.2
         version: 3.4.2(rollup@3.21.0)
       '@unhead/schema-org-vue':
         specifier: ^0.5.0


### PR DESCRIPTION
Fixing the nuxt/kit version sometimes leads to typescript errors due to a difference in the types in two versions of nuxt/kit.